### PR TITLE
[#2] github actions를 이용한 ci 구축

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -1,0 +1,34 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://help.github.com/actions/language-and-framework-guides/building-and-testing-java-with-gradle
+
+name: Java CI with Gradle
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ opened ]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK 17
+      uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+    - name: Build with Gradle
+      run: ./gradlew build
+

--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -30,5 +30,4 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
     - name: Build with Gradle
-      run: ./gradlew build
-
+      run: ./gradlew clean build

--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -12,9 +12,6 @@ on:
     branches: [ main ]
     types: [ opened ]
 
-permissions:
-  contents: read
-
 jobs:
   build:
 


### PR DESCRIPTION
[#2] github actions를 이용한 ci 구축

## 작업 내용 (Content)
- github actions로 pr이 열리면 자동으로 build하도록 합니다.
- pr 후 main branch로 merge하는 경우만 build합니다.

## 기타 사항 (Etc)
- 15~16번째 줄의 `permission` 설정은 제가 참조한 github-actions yml에 있었던 내용이어서 지워도 괜찮은지 알아봤습니다.
- [여기](https://dev.to/azu/how-to-set-github-actions-s-permissions-hln)에서는 이 설정이 software supply chain attack을 방지해준다고 하고 있습니다(원문은 `The permissions field will help you to prevent software supply chain attack.` 입니다.)
- software supply chain attack을 알아보니 배포와 관련된 문제라서 우리 프로젝트에서는 연관이 없지 않을까 생각하지만 확실하지 않아 지우지 않고 남겨뒀습니다.

- `build` 대신 `clean build`를 사용합니다. 조사하면서 두 가지 모두 사용되는 걸 봐서 어느쪽을 쓰는 게 나은지 [찾아보니](https://stackoverflow.com/a/29030305) `build`를 사용할 경우 이전 빌드 산출물이 새로운 빌드와 관계 없어지는 경우가 생길 수 있다고 해서(원문은 `Not doing so(clean build가 아니라 build를 사용하면) may result in an unclean build which may be broken due to build artifacts produced by previous builds.` 입니다.) 이렇게 결정했습니다.

## Merge 전 필요 작업 (Checklist before merge)
- [X] PR 제목에 PR과 연관된 이슈 번호를 [이슈 번호] 형식으로 추가
- [X] 리뷰어 추가

## 리뷰 포인트
- 리뷰어는 리뷰할 때 [Pn 룰](https://github.com/f-lab-edu/sool-dam-a/wiki/프로젝트-문화#코드-리뷰) 을 활용할 수 있습니다.
