### PR TITLE
[#38] Jacoco 연동하기

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
 	id 'org.springframework.boot' version '2.7.4'
 	id 'io.spring.dependency-management' version '1.0.14.RELEASE'
 	id 'java'
+	id 'jacoco'
 }
 
 group = 'com.flab'
@@ -12,6 +13,11 @@ repositories {
 	mavenCentral()
 }
 
+jacoco {
+	toolVersion = "0.8.8"
+	reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 //	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:2.2.2'
@@ -20,4 +26,35 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+}
+
+jacocoTestReport {
+	dependsOn test
+
+	reports {
+		xml.required = false
+		csv.required = false
+		html.outputLocation = layout.buildDirectory.dir('jacocoHtml')
+	}
+
+	finalizedBy jacocoTestCoverageVerification
+}
+
+test {
+	finalizedBy jacocoTestReport
+}
+
+jacocoTestCoverageVerification {
+	violationRules {
+		rule {
+			enabled = true; // true 로 설정하면 포함된 작업에 대한 데이터가 수집됩니다.
+			element = 'CLASS' // Java 요소 유형을 나타냅니다.
+
+			limit { // rule 에 대한 제한을 설정합니다.
+				counter = 'METHOD'
+				value = 'COVEREDRATIO'
+				minimum = 0.7
+			}
+		}
+	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -47,7 +47,7 @@ jacocoTestCoverageVerification {
 	violationRules {
 		rule {
 			enabled = true; // true 로 설정하면 포함된 작업에 대한 데이터가 수집됩니다.
-			element = 'CLASS' //       // 룰을 체크할 단위는 클래스 단위
+			element = 'CLASS' // 룰을 체크할 단위는 클래스 단위
 
 			limit { // rule 에 대한 제한을 설정합니다.
 				counter = 'METHOD'

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,6 @@ repositories {
 
 jacoco {
 	toolVersion = "0.8.8"
-	reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
 }
 
 dependencies {
@@ -48,7 +47,7 @@ jacocoTestCoverageVerification {
 	violationRules {
 		rule {
 			enabled = true; // true 로 설정하면 포함된 작업에 대한 데이터가 수집됩니다.
-			element = 'CLASS' // Java 요소 유형을 나타냅니다.
+			element = 'CLASS' //       // 룰을 체크할 단위는 클래스 단위
 
 			limit { // rule 에 대한 제한을 설정합니다.
 				counter = 'METHOD'


### PR DESCRIPTION
# [#38] Jacoco 연동하기

## 작업 내용 (Content)
- Jacoco 디펜던시를 build.gradle에 추가하여 jacoco를 사용할 수 있게 만들었습니다.

## 기타 사항 (Etc)
- 테스트코드 커버리지의 대상은 Method의 커버비율이며, 70%로 설정해두었습니다.
- jacoco의 html 파일은 build/jacocoHtml 에 생성됩니다.

## Merge 전 필요 작업 (Checklist before merge)
- 

## 리뷰 포인트
- 
