### PR TITLE
[#43] Github Actions 추가 세팅

### DIFF
--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -8,10 +8,9 @@
 name: Java CI with Gradle
 
 on:
-  push:
   pull_request:
     branches: [ main ]
-    types: [ opened ]
+    types: [ opened, synchronize ]
 
 jobs:
   build:

--- a/.github/workflows/build-on-pr.yml
+++ b/.github/workflows/build-on-pr.yml
@@ -8,6 +8,7 @@
 name: Java CI with Gradle
 
 on:
+  push:
   pull_request:
     branches: [ main ]
     types: [ opened ]


### PR DESCRIPTION
[#43] Github Actions 추가 세팅

## 작업 내용 (Content)
- PR open 이후 최신 커밋이 PR 브랜치에 push될 때도 CI를 실행하도록 github actions 설정을 변경했습니다.

## 기타 사항 (Etc)
- 처음 PR이 열릴 때, PR open과 push 두 조건 모두에 해당되어 CI가 두 번 발생합니다.

## Merge 전 필요 작업 (Checklist before merge)
- [x] PR 제목에 PR과 연관된 이슈 번호를 [이슈 번호] 형식으로 추가

## 리뷰 포인트
- 리뷰어는 리뷰할 때 [Pn 룰](https://github.com/f-lab-edu/sool-dam-a/wiki/프로젝트-문화#코드-리뷰) 을 활용할 수 있습니다.
