### PR TITLE
[#69] 클라우드 DB용 profile 추가

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,0 +1,9 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
+  datasource:
+    url: jdbc:mysql://${SERVER_MYSQL_URL}:${SERVER_MYSQL_PORT}/${SERVER_MYSQL_DBNAME}?serverTimezone=UTC&characterEncoding=UTF-8
+    username: ${SERVER_MYSQL_USERNAME}
+    password: ${SERVER_MYSQL_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,4 +1,3 @@
-# Spring
 spring:
   config:
     activate:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,4 +1,3 @@
-# Spring
 spring:
   config:
     activate:


### PR DESCRIPTION
### [#69] 클라우드 DB용 profile 추가

## 작업 내용 (Content)
- 클라우드 DB용 profile 추가

## 기타 사항 (Etc)
- 설정 용도를 고려해 profile 이름을 dev로 설정했습니다.
- 공유 공간에 두지 말아야할 설정값을 변수로 만들었습니다.
  - 인텔리제이에서 애플리케이션을 실행할 경우는 Run - Edit Configuration 메뉴의 Environment Variables에 변수값을 설정해 사용합니다.
  - 터미널 환경에서 애플리케이션을 실행할 때는 다음과 같이 변수별 값을 설정해 사용합니다.
```
java -jar build/libs/sooldama-0.0.1-SNAPSHOT.jar --spring.profiles.active=dev --SERVER_MYSQL_DBNAME='dbname' --SERVER_MYSQL_PASSWORD='password!' --SERVER_MYSQL_PORT='port' --SERVER_MYSQL_URL='url' --SERVER_MYSQL_USERNAME='username'
```

## 셀프 체크리스트
- [x] PR 제목에 PR과 연관된 이슈 번호를 [이슈 번호] 형식으로 추가했나요?
- [x] 구글 자바 포맷터를 잘 활용했나요?
- [x] 추가되는 코드에 대해서 테스트 코드가 작성되었나요?
- [x] 변경된 소스코드가 500라인 이하인가요?
- [x] 객체지향 생활체조 규칙을 지켰나요?
