### PR TITLE
[#78] 로드 밸런서 설정

### DIFF
--- a/src/main/java/com/flab/sooldama/global/api/HealthCheckApi.java
+++ b/src/main/java/com/flab/sooldama/global/api/HealthCheckApi.java
@@ -1,0 +1,19 @@
+package com.flab.sooldama.global.api;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/healthcheck")
+@RequiredArgsConstructor
+public class HealthCheckApi {
+
+	@GetMapping(path = "")
+	public ResponseEntity<Void> healthCheck() {
+		return ResponseEntity.status(HttpStatus.OK).build();
+	}
+}

--- a/src/test/java/com/flab/sooldama/global/api/HealthCheckApiTest.java
+++ b/src/test/java/com/flab/sooldama/global/api/HealthCheckApiTest.java
@@ -1,0 +1,24 @@
+package com.flab.sooldama.global.api;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = HealthCheckApi.class)
+class HealthCheckApiTest {
+	@Autowired
+	MockMvc mockMvc;
+
+	@Test
+	@DisplayName("로드 밸런서 health check 테스트")
+	public void healthCheckSuccessTest() throws Exception {
+		this.mockMvc
+			.perform(get("/healthcheck"))
+			.andExpect(status().isOk());
+	}
+}

--- a/src/test/java/com/flab/sooldama/global/api/HealthCheckApiTest.java
+++ b/src/test/java/com/flab/sooldama/global/api/HealthCheckApiTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 @WebMvcTest(controllers = HealthCheckApi.class)
 class HealthCheckApiTest {
+
 	@Autowired
 	MockMvc mockMvc;
 


### PR DESCRIPTION
### [#78] 로드 밸런서 설정

## 작업 내용 (Content)
- 로드 밸런서의 health check를 위한 api를 생성했습니다.
- 네이버 클라우드에서 설정한 health check url에 요청 시 적절한 상태 코드를 반환하도록 합니다.

## 셀프 체크리스트
- [x] PR 제목에 PR과 연관된 이슈 번호를 [이슈 번호] 형식으로 추가했나요?
- [x] 구글 자바 포맷터를 잘 활용했나요?
- [x] 추가되는 코드에 대해서 테스트 코드가 작성되었나요?
- [x] 변경된 소스코드가 500라인 이하인가요?
- [x] 객체지향 생활체조 규칙을 지켰나요?
